### PR TITLE
Add tinyiiod support

### DIFF
--- a/+adi/+AD4030/Rx.m
+++ b/+adi/+AD4030/Rx.m
@@ -28,7 +28,7 @@ classdef Rx < adi.common.Rx ...
 
     properties (Hidden)
         Timeout = Inf
-        kernelBuffersCount = 4
+        kernelBuffersCount = 1
         dataTypeStr = 'int32'
         phyDevName = 'ad4030-24'
         devName = 'ad4030-24'

--- a/+adi/+AD4630_16/Rx.m
+++ b/+adi/+AD4630_16/Rx.m
@@ -28,7 +28,7 @@ classdef Rx < adi.common.Rx & adi.common.RxTx ...
 
     properties (Hidden)
         Timeout = Inf
-        kernelBuffersCount = 4
+        kernelBuffersCount = 1
         dataTypeStr = 'int32'
         phyDevName = 'ad4630-16'
         devName = 'ad4630-16'

--- a/+adi/+AD4630_24/Rx.m
+++ b/+adi/+AD4630_24/Rx.m
@@ -27,7 +27,7 @@ classdef Rx < adi.common.Rx ...
 
     properties (Hidden)
         Timeout = Inf
-        kernelBuffersCount = 4
+        kernelBuffersCount = 1
         dataTypeStr = 'int32'
         phyDevName = 'ad4630-24'
         devName = 'ad4630-24'

--- a/+adi/+AD463x/Base.m
+++ b/+adi/+AD463x/Base.m
@@ -139,6 +139,13 @@ classdef Base < adi.common.Rx & adi.common.RxTx & ...
 
             obj.set_channel_names();
 
+            contextXML = calllib(obj.libName, 'iio_context_get_xml', obj.iioCtx);
+            if ~contains(contextXML, "no-OS")
+                % It is a Linux platform that MATLAB is talking to.
+                % Changing the buffer count to a more sensible value, 4
+                obj.kernelBuffersCount = 4;
+            end
+
         end
 
         function set_channel_names(obj)

--- a/+adi/+AD7380/Rx.m
+++ b/+adi/+AD7380/Rx.m
@@ -93,6 +93,12 @@ classdef Rx < adi.common.Rx & matlabshared.libiio.base & adi.common.Attribute
             % modification to nontunable variables at SetupImpl
 
             % obj.setDeviceAttributeRAW('sampling_frequency',num2str(obj.SampleRate));
+            contextXML = calllib(obj.libName, 'iio_context_get_xml', obj.iioCtx);
+            if ~contains(contextXML, "no-OS")
+                % It is a Linux platform that MATLAB is talking to.
+                % Changing the buffer count to a more sensible value, 4
+                obj.kernelBuffersCount = 4;
+            end
 
         end
 

--- a/+adi/+AD7380/Rx.m
+++ b/+adi/+AD7380/Rx.m
@@ -46,7 +46,7 @@ classdef Rx < adi.common.Rx & matlabshared.libiio.base & adi.common.Attribute
 
     properties (Nontunable, Hidden)
         Timeout = Inf
-        kernelBuffersCount = 2
+        kernelBuffersCount = 1
         % dataTypeStr = 'int64';
         dataTypeStr = 'int16'
         phyDevName = 'ad7380'

--- a/+adi/+AD7768/Rx.m
+++ b/+adi/+AD7768/Rx.m
@@ -100,6 +100,13 @@ classdef Rx < adi.AD7768.Base & matlabshared.libiio.base & adi.common.Attribute
 
             obj.setDeviceAttributeRAW('sampling_frequency', num2str(obj.SampleRate));
 
+            contextXML = calllib(obj.libName, 'iio_context_get_xml', obj.iioCtx);
+            if ~contains(contextXML, "no-OS")
+                % It is a Linux platform that MATLAB is talking to.
+                % Changing the buffer count to a more sensible value, 4
+                obj.kernelBuffersCount = 4;
+            end
+
         end
 
     end

--- a/+adi/+AD7768/Rx.m
+++ b/+adi/+AD7768/Rx.m
@@ -44,7 +44,7 @@ classdef Rx < adi.AD7768.Base & matlabshared.libiio.base & adi.common.Attribute
 
     properties (Nontunable, Hidden)
         Timeout = Inf
-        kernelBuffersCount = 2
+        kernelBuffersCount = 1
         dataTypeStr = 'int32'
         phyDevName = 'ad7768'
         devName = 'ad7768'

--- a/+adi/+AD7768_1/Rx.m
+++ b/+adi/+AD7768_1/Rx.m
@@ -52,7 +52,7 @@ classdef Rx < adi.AD7768.Base & matlabshared.libiio.base & adi.common.Attribute
 
     properties (Nontunable, Hidden)
         Timeout = Inf
-        kernelBuffersCount = 2
+        kernelBuffersCount = 1
         dataTypeStr = 'int32'
         phyDevName = 'ad7768-1'
         devName = 'ad7768-1'

--- a/+adi/+AD7768_1/Rx.m
+++ b/+adi/+AD7768_1/Rx.m
@@ -122,6 +122,13 @@ classdef Rx < adi.AD7768.Base & matlabshared.libiio.base & adi.common.Attribute
             obj.setDeviceAttributeRAW('sampling_frequency', num2str(obj.SampleRate));
             obj.setDeviceAttributeRAW('common_mode_voltage', obj.CommonModeVolts);
 
+            contextXML = calllib(obj.libName, 'iio_context_get_xml', obj.iioCtx);
+            if ~contains(contextXML, "no-OS")
+                % It is a Linux platform that MATLAB is talking to.
+                % Changing the buffer count to a more sensible value, 4
+                obj.kernelBuffersCount = 4;
+            end
+
         end
 
     end


### PR DESCRIPTION
The SET command handling logic was [recently added/fixed in the no-OS repo](https://github.com/analogdevicesinc/no-OS/commit/f5f6e9fda884db9257544e9e35bcd9f967b15948). As a result, MATLAB will now be able to talk to Tinyiiod firmware, by setting the kernelBuffersCount to 1 (tinyiiod uses just one, circular buffer). 

The default, and only permissible, value of kernelBuffersCount for Tinyiiod platforms is 1. For linux, the default is chosen as 4. The platform check is implemented by reading the context xml and checking for the presence of "no-OS" in the description.