### PR TITLE
docs:workflows: Remove docs destination directory

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,4 +26,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc
-          destination_dir: master


### PR DESCRIPTION
1. Remove the destination directory from the yml file to simplify the url for the documentation