### PR TITLE
adi:AD7606x:Add support for AD7606x family of parts

### DIFF
--- a/+adi/+AD7605_4/Rx.m
+++ b/+adi/+AD7605_4/Rx.m
@@ -1,0 +1,25 @@
+classdef Rx < adi.common.Rx & adi.common.RxTx ...
+        & adi.AD7606x.Base
+    % AD7605-4 Precision ADC Class
+    % 
+    % adi.AD7605_4.Rx Receives data from the AD7605 ADC
+    % The adi.AD7605_4.Rx System object is a signal source that can receive
+    % data from the AD7605-4.
+    %
+    %   `rx = adi.AD7605_4.Rx;`
+    %   `rx = adi.AD7605_4.Rx('uri','ip:192.168.2.1');`
+    %
+    % `AD7605-4 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad7605-4.pdf>`_
+
+    properties (Nontunable, Hidden)
+        channel_names = {'voltage0','voltage1','voltage2','voltage3'};
+    end
+
+    methods
+        %% Constructor
+        function obj = Rx(varargin)
+            obj = obj@adi.AD7606x.Base('ad7605-4','ad7605-4','int16',varargin{:});
+        end
+    end
+    
+ end  

--- a/+adi/+AD7606B/Rx.m
+++ b/+adi/+AD7606B/Rx.m
@@ -1,0 +1,25 @@
+classdef Rx < adi.common.Rx & adi.common.RxTx ...
+        & adi.AD7606x.Base
+    % AD7606B Precision ADC Class
+    % 
+    % adi.AD7606B.Rx Receives data from the AD7606B ADC
+    % The adi.AD7606B.Rx System object is a signal source that can receive
+    % data from the AD7606B.
+    %
+    %   `rx = adi.AD7606B.Rx;`
+    %   `rx = adi.AD7606B.Rx('uri','ip:192.168.2.1');`
+    %
+    % `AD7606 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606_7606-6_7606-4.pdf>`_
+
+    properties (Nontunable, Hidden)
+        channel_names = {'voltage0','voltage1','voltage2','voltage3','voltage4','voltage5','voltage6','voltage7'};
+    end
+
+    methods
+        %% Constructor
+        function obj = Rx(varargin)
+            obj = obj@adi.AD7606x.Base('ad7606b','ad7606b','int16',varargin{:});
+        end
+    end
+    
+ end  

--- a/+adi/+AD7606C_16/Rx.m
+++ b/+adi/+AD7606C_16/Rx.m
@@ -1,0 +1,25 @@
+classdef Rx < adi.common.Rx & adi.common.RxTx ...
+        & adi.AD7606x.Base
+    % AD7606C-16 Precision ADC Class
+    % 
+    % adi.AD7606C_16.Rx Receives data from the AD7606C-16 ADC
+    % The adi.AD7606C_16.Rx System object is a signal source that can receive
+    % data from the AD7606C-16.
+    %
+    %   `rx = adi.AD7606C_16.Rx;`
+    %   `rx = adi.AD7606C_16.Rx('uri','ip:192.168.2.1');`
+    %
+    % `AD7606 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606_7606-6_7606-4.pdf>`_
+
+    properties (Nontunable, Hidden)
+        channel_names = {'voltage0','voltage1','voltage2','voltage3','voltage4','voltage5','voltage6','voltage7'};
+    end
+
+    methods
+        %% Constructor
+        function obj = Rx(varargin)
+            obj = obj@adi.AD7606x.Base('ad7606c-16','ad7606c-16','int16',varargin{:});
+        end
+    end
+    
+ end  

--- a/+adi/+AD7606C_18/Rx.m
+++ b/+adi/+AD7606C_18/Rx.m
@@ -1,0 +1,25 @@
+classdef Rx < adi.common.Rx & adi.common.RxTx ...
+        & adi.AD7606x.Base
+    % AD7606C-18 Precision ADC Class
+    % 
+    % adi.AD7606C_18.Rx Receives data from the AD7606C-18 ADC
+    % The adi.AD7606C_18.Rx System object is a signal source that can receive
+    % data from the AD7606C-18.
+    %
+    %   `rx = adi.AD7606C_18.Rx;`
+    %   `rx = adi.AD7606C_18.Rx('uri','ip:192.168.2.1');`
+    %
+    % `AD7606 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606_7606-6_7606-4.pdf>`_
+
+    properties (Nontunable, Hidden)
+        channel_names = {'voltage0','voltage1','voltage2','voltage3','voltage4','voltage5','voltage6','voltage7'};
+    end
+
+    methods
+        %% Constructor
+        function obj = Rx(varargin)
+            obj = obj@adi.AD7606x.Base('ad7606c-18','ad7606c-18','int32',varargin{:});
+        end
+    end
+    
+ end  

--- a/+adi/+AD7606_4/Rx.m
+++ b/+adi/+AD7606_4/Rx.m
@@ -1,0 +1,25 @@
+classdef Rx < adi.common.Rx & adi.common.RxTx ...
+        & adi.AD7606x.Base
+    % AD7606-4 Precision ADC Class
+    % 
+    % adi.AD7606_4.Rx Receives data from the AD7606-4 ADC
+    % The adi.AD7606-4.Rx System object is a signal source that can receive
+    % data from the AD7606-4.
+    %
+    %   `rx = adi.AD7606_4.Rx;`
+    %   `rx = adi.AD7606_4.Rx('uri','ip:192.168.2.1');`
+    %
+    % `AD7606-4 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606_7606-4_7606-4.pdf>`_
+
+    properties (Nontunable, Hidden)
+        channel_names = {'voltage0','voltage1','voltage2','voltage3'};
+    end
+
+    methods
+        %% Constructor
+        function obj = Rx(varargin)
+            obj = obj@adi.AD7606x.Base('ad7606-4','ad7606-4','int16',varargin{:});
+        end
+    end
+    
+ end  

--- a/+adi/+AD7606_6/Rx.m
+++ b/+adi/+AD7606_6/Rx.m
@@ -1,0 +1,25 @@
+classdef Rx < adi.common.Rx & adi.common.RxTx ...
+        & adi.AD7606x.Base
+    % AD7606-6 Precision ADC Class
+    % 
+    % adi.AD7606_6.Rx Receives data from the AD7606-6 ADC
+    % The adi.AD7606-6.Rx System object is a signal source that can receive
+    % data from the AD7606-6.
+    %
+    %   `rx = adi.AD7606_4.Rx;`
+    %   `rx = adi.AD7606_4.Rx('uri','ip:192.168.2.1');`
+    %
+    % `AD7606-6 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606_7606-6_7606-4.pdf>`_
+
+    properties (Nontunable, Hidden)
+        channel_names = {'voltage0','voltage1','voltage2','voltage3','voltage4','voltage5'};
+    end
+
+    methods
+        %% Constructor
+        function obj = Rx(varargin)
+            obj = obj@adi.AD7606x.Base('ad7606-6','ad7606-6','int16',varargin{:});
+        end
+    end
+    
+ end  

--- a/+adi/+AD7606_8/Rx.m
+++ b/+adi/+AD7606_8/Rx.m
@@ -1,0 +1,26 @@
+classdef Rx < adi.common.Rx & adi.common.RxTx ...
+        & adi.AD7606x.Base
+    % AD7606-8 Precision ADC Class
+    % 
+    % adi.AD7606_8.Rx Receives data from the AD7606-8 ADC
+    % The adi.AD7606_8.Rx System object is a signal source that can receive
+    % data from the AD7606-8.
+    % In the datasheet, this is referred to as 'AD7606'.
+    %
+    %   `rx = adi.AD7606_8.Rx;`
+    %   `rx = adi.AD7606_8.Rx('uri','ip:192.168.2.1');`
+    %
+    % `AD7606 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606_7606-6_7606-4.pdf>`_
+
+    properties (Nontunable, Hidden)
+        channel_names = {'voltage0','voltage1','voltage2','voltage3','voltage4','voltage5','voltage6','voltage7'};
+    end
+
+    methods
+        %% Constructor
+        function obj = Rx(varargin)
+            obj = obj@adi.AD7606x.Base('ad7606-8','ad7606-8','int16',varargin{:});
+        end
+    end
+    
+ end  

--- a/+adi/+AD7606x/Base.m
+++ b/+adi/+AD7606x/Base.m
@@ -1,0 +1,88 @@
+classdef Base < adi.common.Rx & adi.common.RxTx & ...
+         matlabshared.libiio.base & adi.common.Attribute & ...
+         adi.common.RegisterReadWrite & adi.common.Channel
+    % AD7606x Precision ADC Class
+
+    properties (Nontunable)
+        % SamplesPerFrame Samples Per Frame
+        %   Number of samples per frame, specified as an even positive
+        %   integer.
+        SamplesPerFrame = 400
+    end
+    
+    % isOutput
+    properties (Hidden, Nontunable, Access = protected)
+        isOutput = false
+    end
+
+    properties (Nontunable, Hidden, Constant)
+        Type = 'Rx'
+    end
+
+    properties (Nontunable, Hidden)
+        Timeout = Inf
+        kernelBuffersCount = 1
+        dataTypeStr
+        phyDevName
+        devName
+    end
+
+    properties (Hidden, Constant)
+        ComplexData = false
+    end
+
+    methods
+    %% Constructor
+        function obj = Base(phydev,dev,dataTypeStr,varargin)
+            coder.allowpcode('plain');
+            % Initialize the Rx object
+            obj = obj@matlabshared.libiio.base(varargin{:});
+            obj.enableExplicitPolling = false;
+            obj.EnabledChannels = 1;
+            obj.BufferTypeConversionEnable = true;
+            obj.phyDevName = phydev;
+            obj.devName = dev;
+            obj.dataTypeStr = dataTypeStr;
+            obj.uri = 'ip:analog.local';
+        end
+
+        function flush(obj)
+            % Flush the buffer
+            flushBuffers(obj);
+        end
+
+        function delete(obj)
+            % Destructor
+            delete@adi.common.RxTx(obj);
+        end
+
+    end
+
+    %% API Functions
+    methods (Hidden, Access = protected)
+        function setupInit(obj)
+            % Write all attributes to device once connected through set
+            % methods
+            % Do writes directly to hardware without using set methods.
+            % This is required since Simulink support doesn't support
+            % modification to nontunable variables at SetupImpl
+        end
+    end
+
+     %% External Dependency Methods
+    methods (Hidden, Static)
+        function tf = isSupportedContext(bldCfg)
+            tf = matlabshared.libiio.ExternalDependency.isSupportedContext(bldCfg);
+        end
+
+        function updateBuildInfo(buildInfo, bldCfg)
+            % Call the matlabshared.libiio.method first
+            matlabshared.libiio.ExternalDependency.updateBuildInfo(buildInfo, bldCfg);
+        end
+
+        function bName = getDescriptiveName(~)
+            bName = 'AD7606x ADC';
+        end
+    end
+    
+end

--- a/+adi/Contents.m
+++ b/+adi/Contents.m
@@ -31,6 +31,13 @@
 %   <a href="matlab:help adi.AD7626            ">AD7626</a>         - ADC
 %   <a href="matlab:help adi.AD7960            ">AD7960</a>         - ADC
 %   <a href="matlab:help adi.AD7961            ">AD7961</a>         - ADC
+%   <a href="matlab:help adi.AD7605_4          ">AD7605_4</a>       - ADC
+%   <a href="matlab:help adi.AD7606_4          ">AD7606_4</a>       - ADC
+%   <a href="matlab:help adi.AD7606_6          ">AD7606_6</a>       - ADC
+%   <a href="matlab:help adi.AD7606_8          ">AD7606_8</a>       - ADC
+%   <a href="matlab:help adi.AD7606B           ">AD7606B</a>        - ADC
+%   <a href="matlab:help adi.AD7606C_16        ">AD7606C_16</a>     - ADC
+%   <a href="matlab:help adi.AD7606C_18        ">AD7606C_18</a>     - ADC
 %   <a href="matlab:help adi.AD7768            ">AD7768</a>         - ADC
 %   <a href="matlab:help adi.AD7768_1          ">AD7768-1</a>       - ADC
 %   <a href="matlab:help adi.AD2S1210          ">AD2S1210</a>       - Resolver-to-Digital Converter

--- a/examples/ad7606B_DataCapture.m
+++ b/examples/ad7606B_DataCapture.m
@@ -1,0 +1,27 @@
+%% Script for capturing and displaying a continuous set of samples from a 
+%% connected AD7606B board
+
+%% Trigger setup needs to be performed before this example script can be run
+%% Refer to the Limitations section in the documentation for details
+
+% Instantiate the system object
+rx = adi.AD7606B.Rx;
+% Specify uri
+rx.uri = 'ip:analog.local';
+rx.SamplesPerFrame = 4096;  % Using values less than 3660 can yield poor 
+% performance, generally
+rx.EnabledChannels = [1 2];
+
+% Capture data
+data = rx();
+
+enabledChannels = size(data, 2);
+figure(1);
+for i = 1:enabledChannels
+    subplot(enabledChannels, 1, i);
+    plot(data(1:rx.SamplesPerFrame, i));
+    title("Channel " + num2str(rx.EnabledChannels(i)));
+end
+
+% Delete the system object
+release(rx);


### PR DESCRIPTION
This change adds support for AD7605-4, AD7606-4, AD7606-6, AD7606-8, AD7606B, AD7606C-16 and AD7606C-18 parts.

All these parts are in the same family of precision ADCs.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation by running /docs/source/reference_api/gen_sysobj_doc.m script locally, if applies.