### PR TITLE
AD400x: fix sign for even-numbered devices

### DIFF
--- a/+adi/+AD4000/Rx.m
+++ b/+adi/+AD4000/Rx.m
@@ -10,13 +10,33 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4000 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4000-4004-4008.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
-            obj = obj@adi.AD400x.Base('ad4000', 'ad4000', 'int16', varargin{:});
+            obj = obj@adi.AD400x.Base('ad4000', 'ad4000', 'uint16', varargin{:});
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4001/Rx.m
+++ b/+adi/+AD4001/Rx.m
@@ -10,6 +10,18 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4001 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4001-4005.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0-voltage1'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
@@ -17,6 +29,14 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4002/Rx.m
+++ b/+adi/+AD4002/Rx.m
@@ -10,13 +10,33 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4002 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4002-4006-4010.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
-            obj = obj@adi.AD400x.Base('ad4002', 'ad4002', 'int32', varargin{:});
+            obj = obj@adi.AD400x.Base('ad4002', 'ad4002', 'uint32', varargin{:});
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4003/Rx.m
+++ b/+adi/+AD4003/Rx.m
@@ -10,6 +10,18 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4003 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4003-4007-4011.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0-voltage1'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
@@ -17,6 +29,14 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4004/Rx.m
+++ b/+adi/+AD4004/Rx.m
@@ -10,13 +10,33 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4004 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4000-4004-4008.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
-            obj = obj@adi.AD400x.Base('ad4004', 'ad4004', 'int16', varargin{:});
+            obj = obj@adi.AD400x.Base('ad4004', 'ad4004', 'uint32', varargin{:});
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4005/Rx.m
+++ b/+adi/+AD4005/Rx.m
@@ -10,6 +10,18 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4005 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4001-4005.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0-voltage1'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
@@ -17,6 +29,14 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4006/Rx.m
+++ b/+adi/+AD4006/Rx.m
@@ -10,13 +10,33 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4006 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4002-4006-4010.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
-            obj = obj@adi.AD400x.Base('ad4006', 'ad4006', 'int32', varargin{:});
+            obj = obj@adi.AD400x.Base('ad4006', 'ad4006', 'uint32', varargin{:});
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4007/Rx.m
+++ b/+adi/+AD4007/Rx.m
@@ -10,6 +10,18 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4007 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4003-4007-4011.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0-voltage1'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
@@ -17,6 +29,14 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4008/Rx.m
+++ b/+adi/+AD4008/Rx.m
@@ -10,13 +10,33 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4008 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4000-4004-4008.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
-            obj = obj@adi.AD400x.Base('ad4008', 'ad4008', 'int16', varargin{:});
+            obj = obj@adi.AD400x.Base('ad4008', 'ad4008', 'uint32', varargin{:});
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD400x/Base.m
+++ b/+adi/+AD400x/Base.m
@@ -12,11 +12,6 @@ classdef Base < adi.common.Rx & matlabshared.libiio.base & adi.common.Attribute
         %   Number of samples per frame, specified as an even positive
         %   integer.
         SamplesPerFrame = 4096
-
-	% SampleRate Sample Rate
-	%   Baseband sampling rate in Hz, specified as a scalar
-	%   in samples per second.
-	SampleRate = '500000'
     end
 
     properties (Dependent)
@@ -27,11 +22,6 @@ classdef Base < adi.common.Rx & matlabshared.libiio.base & adi.common.Attribute
         % VoltageOffset Voltage Offset
         %   ADC Voltage offset.
         VoltageOffset
-    end
-
-    % Channel names
-    properties (Nontunable, Hidden, Constant)
-        channel_names = {'voltage0'}
     end
 
     % isOutput
@@ -64,19 +54,10 @@ classdef Base < adi.common.Rx & matlabshared.libiio.base & adi.common.Attribute
 	    obj.dataTypeStr = dtype;
         end
 
-	%% Set SampleRate
-	function set.SampleRate(obj, value)
-	    % Set device sampling rate
-	    obj.SampleRate = value;
-	    if obj.ConnectedToDevice
-	        obj.setDeviceAttributeRAW('sampling_frequency', num2str(value));
-	    end
-	end
-
         %% Check Voltage Scale
         function rValue = get.VoltageScale(obj)
             if obj.ConnectedToDevice
-                rValue = obj.getAttributeDouble('voltage0', 'scale', obj.isOutput);
+                rValue = obj.getAttributeDouble(char(obj.channel_names(1)), 'scale', obj.isOutput);
             else
                 rValue = NaN;
             end
@@ -85,7 +66,7 @@ classdef Base < adi.common.Rx & matlabshared.libiio.base & adi.common.Attribute
         %% Check Voltage Offset
         function rValue = get.VoltageOffset(obj)
             if obj.ConnectedToDevice
-                rValue = obj.getAttributeDouble('voltage0', 'offset', obj.isOutput);
+                rValue = obj.getAttributeDouble(char(obj.channel_names(1)), 'offset', obj.isOutput);
             else
                 rValue = NaN;
             end
@@ -94,9 +75,7 @@ classdef Base < adi.common.Rx & matlabshared.libiio.base & adi.common.Attribute
 
     %% API Functions
     methods (Hidden, Access = protected)
-        function setupInit(obj)
-	    obj.setDeviceAttributeRAW('sampling_frequency', ...
-	                              num2str(obj.SampleRate));
+        function setupInit(~)
         end
     end
 end

--- a/+adi/+AD4010/Rx.m
+++ b/+adi/+AD4010/Rx.m
@@ -10,13 +10,33 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4010 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4002-4006-4010.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
-            obj = obj@adi.AD400x.Base('ad4010', 'ad4010', 'int32', varargin{:});
+            obj = obj@adi.AD400x.Base('ad4010', 'ad4010', 'uint32', varargin{:});
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4011/Rx.m
+++ b/+adi/+AD4011/Rx.m
@@ -10,6 +10,18 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4011 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4003-4007-4011.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0-voltage1'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
@@ -17,6 +29,14 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4020/0001-AD4020-try-isolating.patch
+++ b/+adi/+AD4020/0001-AD4020-try-isolating.patch
@@ -1,0 +1,120 @@
+From 849166893ffa1841a03dee595a5ac9a4b6493b4b Mon Sep 17 00:00:00 2001
+From: Trevor Gamblin <tgamblin@baylibre.com>
+Date: Tue, 4 Feb 2025 17:11:04 -0500
+Subject: [PATCH] AD4020: try isolating
+
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
+---
+ +adi/+AD4020/Rx.m | 88 +++++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 86 insertions(+), 2 deletions(-)
+
+diff --git a/+adi/+AD4020/Rx.m b/+adi/+AD4020/Rx.m
+index b5fd904..7468f15 100644
+--- a/+adi/+AD4020/Rx.m
++++ b/+adi/+AD4020/Rx.m
+@@ -1,4 +1,4 @@
+-classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
++classdef Rx < matlabshared.libiio.base & adi.common.Attribute
+     % AD4020 Precision ADC Class
+     % 
+     % adi.AD4020.Rx Receives data from the AD4020 ADC
+@@ -10,11 +10,95 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
+     %
+     % `AD4020 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4020-4021-4022.pdf>`_
+ 
+-    % Channel names
++    properties (Nontunable)
++        % SamplesPerFrame Samples Per Frame
++        %   Number of samples per frame, specified as an even positive
++        %   integer.
++        SamplesPerFrame = 4096
++
++	% SampleRate Sample Rate
++	%   Baseband sampling rate in Hz, specified as a scalar
++	%   in samples per second.
++	SampleRate = '500000'
++    end
++
++    properties (Dependent)
++        % VoltageScale Voltage Scale
++        %   ADC Voltage scale.
++        VoltageScale
++
++        % VoltageOffset Voltage Offset
++        %   ADC Voltage offset.
++        VoltageOffset
++    end
++
++    % isOutput
++    properties (Hidden, Nontunable, Access = protected)
++        isOutput = false
++    end
++
++    properties (Nontunable, Hidden)
++        Timeout = Inf
++        kernelBuffersCount = 1
++        dataTypeStr
++        phyDevName
++        devName
++    end
++
+     properties (Nontunable, Hidden, Constant)
++        Type = 'Rx'
+         channel_names = {'voltage0-voltage1'}
+     end
+ 
++    properties (Hidden, Constant)
++        ComplexData = false
++    end
++
++    methods
++        %% Constructor
++        function obj = Base(phydev, dev, dtype, varargin)
++            obj = obj@matlabshared.libiio.base(varargin{:});
++	    obj.phyDevName = phydev;
++	    obj.devName = dev;
++	    obj.dataTypeStr = dtype;
++        end
++
++	%% Set SampleRate
++	function set.SampleRate(obj, value)
++	    % Set device sampling rate
++	    obj.SampleRate = value;
++	    if obj.ConnectedToDevice
++	        obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(value), false);
++	    end
++	end
++
++        %% Check Voltage Scale
++        function rValue = get.VoltageScale(obj)
++            if obj.ConnectedToDevice
++                rValue = obj.getAttributeDouble('voltage0-voltage1', 'scale', obj.isOutput);
++            else
++                rValue = NaN;
++            end
++        end
++
++        %% Check Voltage Offset
++        function rValue = get.VoltageOffset(obj)
++            if obj.ConnectedToDevice
++                rValue = obj.getAttributeDouble('voltage0-voltage1', 'offset', obj.isOutput);
++            else
++                rValue = NaN;
++            end
++        end
++    end
++
++    %% API Functions
++    methods (Hidden, Access = protected)
++        function setupInit(obj)
++	    obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(obj.SampleRate), false);
++        end
++    end
++end
++
+     methods
+         %% Constructor
+         function obj = Rx(varargin)
+-- 
+2.39.5
+

--- a/+adi/+AD4020/0001-docs-source-reference_api-update.patch
+++ b/+adi/+AD4020/0001-docs-source-reference_api-update.patch
@@ -1,0 +1,765 @@
+From cb89f3177819b43a993ff3fccf521822538f6669 Mon Sep 17 00:00:00 2001
+From: Trevor Gamblin <tgamblin@baylibre.com>
+Date: Wed, 5 Feb 2025 21:00:55 +0100
+Subject: [PATCH] docs/source/reference_api: update
+
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
+---
+ docs/source/reference_api/AD4000_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4001_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4002_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4003_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4004_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4005_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4006_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4007_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4008_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4010_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4011_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4020_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4021_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4022_Rx.rst    | 15 ++++++---------
+ docs/source/reference_api/AD4030_Rx.rst    | 10 +++++-----
+ docs/source/reference_api/AD4052_Rx.rst    | 16 ++++++++--------
+ docs/source/reference_api/AD4630_16_Rx.rst | 10 +++++-----
+ docs/source/reference_api/AD4630_24_Rx.rst | 10 +++++-----
+ docs/source/reference_api/AD5760_Tx.rst    | 20 ++++++++++----------
+ docs/source/reference_api/AD5780_Tx.rst    | 20 ++++++++++----------
+ docs/source/reference_api/AD5781_Tx.rst    | 20 ++++++++++----------
+ docs/source/reference_api/AD5790_Tx.rst    | 20 ++++++++++----------
+ docs/source/reference_api/AD5791_Tx.rst    | 20 ++++++++++----------
+ docs/source/reference_api/AD7380_Rx.rst    |  7 +++++--
+ 24 files changed, 162 insertions(+), 201 deletions(-)
+
+diff --git a/docs/source/reference_api/AD4000_Rx.rst b/docs/source/reference_api/AD4000_Rx.rst
+index 19f1a80..faa7629 100644
+--- a/docs/source/reference_api/AD4000_Rx.rst
++++ b/docs/source/reference_api/AD4000_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4000.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4000.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4000.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4000.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4000.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4000.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4001_Rx.rst b/docs/source/reference_api/AD4001_Rx.rst
+index 174680f..8d2255d 100644
+--- a/docs/source/reference_api/AD4001_Rx.rst
++++ b/docs/source/reference_api/AD4001_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4001.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4001.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4001.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4001.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4001.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4001.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4002_Rx.rst b/docs/source/reference_api/AD4002_Rx.rst
+index fcb989e..e478d21 100644
+--- a/docs/source/reference_api/AD4002_Rx.rst
++++ b/docs/source/reference_api/AD4002_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4002.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4002.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4002.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4002.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4002.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4002.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4003_Rx.rst b/docs/source/reference_api/AD4003_Rx.rst
+index 042d01f..a993b0a 100644
+--- a/docs/source/reference_api/AD4003_Rx.rst
++++ b/docs/source/reference_api/AD4003_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4003.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4003.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4003.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4003.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4003.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4003.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4004_Rx.rst b/docs/source/reference_api/AD4004_Rx.rst
+index 1269916..de20599 100644
+--- a/docs/source/reference_api/AD4004_Rx.rst
++++ b/docs/source/reference_api/AD4004_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4004.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4004.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4004.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4004.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4004.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4004.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4005_Rx.rst b/docs/source/reference_api/AD4005_Rx.rst
+index f41fc76..cf56b35 100644
+--- a/docs/source/reference_api/AD4005_Rx.rst
++++ b/docs/source/reference_api/AD4005_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4005.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4005.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4005.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4005.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4005.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4005.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4006_Rx.rst b/docs/source/reference_api/AD4006_Rx.rst
+index 9a60832..5617245 100644
+--- a/docs/source/reference_api/AD4006_Rx.rst
++++ b/docs/source/reference_api/AD4006_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4006.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4006.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4006.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4006.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4006.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4006.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4007_Rx.rst b/docs/source/reference_api/AD4007_Rx.rst
+index 7e8ff95..69c0a3a 100644
+--- a/docs/source/reference_api/AD4007_Rx.rst
++++ b/docs/source/reference_api/AD4007_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4007.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4007.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4007.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4007.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4007.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4007.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4008_Rx.rst b/docs/source/reference_api/AD4008_Rx.rst
+index 63acf70..52b28c8 100644
+--- a/docs/source/reference_api/AD4008_Rx.rst
++++ b/docs/source/reference_api/AD4008_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4008.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4008.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4008.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4008.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4008.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4008.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4010_Rx.rst b/docs/source/reference_api/AD4010_Rx.rst
+index 8dc97a8..1545a35 100644
+--- a/docs/source/reference_api/AD4010_Rx.rst
++++ b/docs/source/reference_api/AD4010_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4010.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4010.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4010.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4010.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4010.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4010.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4011_Rx.rst b/docs/source/reference_api/AD4011_Rx.rst
+index 5888bb4..799db13 100644
+--- a/docs/source/reference_api/AD4011_Rx.rst
++++ b/docs/source/reference_api/AD4011_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4011.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4011.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4011.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4011.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4011.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4011.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4020_Rx.rst b/docs/source/reference_api/AD4020_Rx.rst
+index 079dd6b..b13645c 100644
+--- a/docs/source/reference_api/AD4020_Rx.rst
++++ b/docs/source/reference_api/AD4020_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4020.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4020.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4020.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4020.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4020.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4020.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4021_Rx.rst b/docs/source/reference_api/AD4021_Rx.rst
+index e80171d..b96cb0c 100644
+--- a/docs/source/reference_api/AD4021_Rx.rst
++++ b/docs/source/reference_api/AD4021_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4021.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4021.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4021.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4021.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4021.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4021.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4022_Rx.rst b/docs/source/reference_api/AD4022_Rx.rst
+index 3fcb07b..e41c37e 100644
+--- a/docs/source/reference_api/AD4022_Rx.rst
++++ b/docs/source/reference_api/AD4022_Rx.rst
+@@ -18,17 +18,14 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4022.Rx/SampleRate is inherited from superclass adi.AD400x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4022.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4022.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
++**VoltageOffset - Voltage Offset**
++   ADC Voltage offset.
+ 
+-**VoltageOffset Voltage Offset**
+-   ADC Voltage offset.Help for adi.AD4022.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+-
+-**VoltageScale Voltage Scale**
+-   ADC Voltage scale.Help for adi.AD4022.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
++**VoltageScale - Voltage Scale**
++   ADC Voltage scale.
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4022.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4030_Rx.rst b/docs/source/reference_api/AD4030_Rx.rst
+index f02abbd..0623c00 100644
+--- a/docs/source/reference_api/AD4030_Rx.rst
++++ b/docs/source/reference_api/AD4030_Rx.rst
+@@ -19,13 +19,13 @@ Class Properties
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+ **SampleAveragingLength**
+-   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential modeHelp for adi.AD4030.Rx/SampleAveragingLength is inherited from superclass adi.AD463x.Base
++   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential mode
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4030.Rx/SampleRate is inherited from superclass adi.AD463x.Base
++**SampleRate - Sample Rate**
++   Baseband sampling rate in Hz, specified as a scalar in samples per second.
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4030.Rx/SamplesPerFrame is inherited from superclass adi.AD463x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4030.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4030.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4052_Rx.rst b/docs/source/reference_api/AD4052_Rx.rst
+index cd71825..cb46c19 100644
+--- a/docs/source/reference_api/AD4052_Rx.rst
++++ b/docs/source/reference_api/AD4052_Rx.rst
+@@ -15,20 +15,20 @@ data from the AD4052.
+ Class Properties
+ ================
+ 
+-**BurstAveragingLength Burst Averaging Length**
+-   Length of the averaging filter in 'burst averaging mode'Help for adi.AD4052.Rx/AvgFilterLength is inherited from superclass adi.AD405x.Base
++**AvgFilterLength - BurstAveragingLength Burst Averaging Length**
++   Length of the averaging filter in 'burst averaging mode'
+ 
+-**BurstSampleRate Burst Sample Rate**
+-   Rate of internal averaging in 'burst averaging mode'Help for adi.AD4052.Rx/BurstSampleRate is inherited from superclass adi.AD405x.Base
++**BurstSampleRate - Burst Sample Rate**
++   Rate of internal averaging in 'burst averaging mode'
+ 
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4052.Rx/SampleRate is inherited from superclass adi.AD405x.Base
++**SampleRate - Sample Rate**
++   Baseband sampling rate in Hz, specified as a scalar in samples per second.
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4052.Rx/SamplesPerFrame is inherited from superclass adi.AD405x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4052.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4052.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4630_16_Rx.rst b/docs/source/reference_api/AD4630_16_Rx.rst
+index b4c1da9..19250e4 100644
+--- a/docs/source/reference_api/AD4630_16_Rx.rst
++++ b/docs/source/reference_api/AD4630_16_Rx.rst
+@@ -19,13 +19,13 @@ Class Properties
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+ **SampleAveragingLength**
+-   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential modeHelp for adi.AD4630_16.Rx/SampleAveragingLength is inherited from superclass adi.AD463x.Base
++   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential mode
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4630_16.Rx/SampleRate is inherited from superclass adi.AD463x.Base
++**SampleRate - Sample Rate**
++   Baseband sampling rate in Hz, specified as a scalar in samples per second.
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4630_16.Rx/SamplesPerFrame is inherited from superclass adi.AD463x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4630_16.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4630_16.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD4630_24_Rx.rst b/docs/source/reference_api/AD4630_24_Rx.rst
+index 86113c0..ad663b0 100644
+--- a/docs/source/reference_api/AD4630_24_Rx.rst
++++ b/docs/source/reference_api/AD4630_24_Rx.rst
+@@ -19,13 +19,13 @@ Class Properties
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+ **SampleAveragingLength**
+-   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential modeHelp for adi.AD4630_24.Rx/SampleAveragingLength is inherited from superclass adi.AD463x.Base
++   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential mode
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4630_24.Rx/SampleRate is inherited from superclass adi.AD463x.Base
++**SampleRate - Sample Rate**
++   Baseband sampling rate in Hz, specified as a scalar in samples per second.
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4630_24.Rx/SamplesPerFrame is inherited from superclass adi.AD463x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD4630_24.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD4630_24.Rx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD5760_Tx.rst b/docs/source/reference_api/AD5760_Tx.rst
+index 9f43205..f47b27a 100644
+--- a/docs/source/reference_api/AD5760_Tx.rst
++++ b/docs/source/reference_api/AD5760_Tx.rst
+@@ -15,8 +15,8 @@ data to the AD5760.
+ Class Properties
+ ================
+ 
+-**CodeSelect Code Select**
+-   Set to 2s_complement/offset_binaryHelp for adi.AD5760.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
++**CodeSelect - Code Select**
++   Set to 2s_complement/offset_binary
+ 
+ **DDSFrequencies DDS Frequencies**
+    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5760.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
+@@ -36,17 +36,17 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**PowerDown Power Down**
+-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5760.Tx/PowerDown is inherited from superclass adi.AD579x.Base
++**PowerDown - Power Down**
++   Set to true/false to power-up/power-down the device channels
+ 
+-**Raw Channel Raw Value**
+-   Help for adi.AD5760.Tx/Raw is inherited from superclass adi.AD579x.Base
++**Raw - Channel Raw Value**
++   
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5760.Tx/SampleRate is inherited from superclass adi.AD579x.Base
++**SampleRate - Sample Rate**
++   Baseband sampling rate in Hz, specified as a scalar in samples per second.
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5760.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD5760.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD5760.Tx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD5780_Tx.rst b/docs/source/reference_api/AD5780_Tx.rst
+index e402756..74d6617 100644
+--- a/docs/source/reference_api/AD5780_Tx.rst
++++ b/docs/source/reference_api/AD5780_Tx.rst
+@@ -15,8 +15,8 @@ data to the AD5780.
+ Class Properties
+ ================
+ 
+-**CodeSelect Code Select**
+-   Set to 2s_complement/offset_binaryHelp for adi.AD5780.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
++**CodeSelect - Code Select**
++   Set to 2s_complement/offset_binary
+ 
+ **DDSFrequencies DDS Frequencies**
+    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5780.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
+@@ -36,17 +36,17 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**PowerDown Power Down**
+-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5780.Tx/PowerDown is inherited from superclass adi.AD579x.Base
++**PowerDown - Power Down**
++   Set to true/false to power-up/power-down the device channels
+ 
+-**Raw Channel Raw Value**
+-   Help for adi.AD5780.Tx/Raw is inherited from superclass adi.AD579x.Base
++**Raw - Channel Raw Value**
++   
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5780.Tx/SampleRate is inherited from superclass adi.AD579x.Base
++**SampleRate - Sample Rate**
++   Baseband sampling rate in Hz, specified as a scalar in samples per second.
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5780.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD5780.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD5780.Tx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD5781_Tx.rst b/docs/source/reference_api/AD5781_Tx.rst
+index 0f1156d..0975e77 100644
+--- a/docs/source/reference_api/AD5781_Tx.rst
++++ b/docs/source/reference_api/AD5781_Tx.rst
+@@ -15,8 +15,8 @@ data to the AD5781.
+ Class Properties
+ ================
+ 
+-**CodeSelect Code Select**
+-   Set to 2s_complement/offset_binaryHelp for adi.AD5781.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
++**CodeSelect - Code Select**
++   Set to 2s_complement/offset_binary
+ 
+ **DDSFrequencies DDS Frequencies**
+    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5781.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
+@@ -36,17 +36,17 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**PowerDown Power Down**
+-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5781.Tx/PowerDown is inherited from superclass adi.AD579x.Base
++**PowerDown - Power Down**
++   Set to true/false to power-up/power-down the device channels
+ 
+-**Raw Channel Raw Value**
+-   Help for adi.AD5781.Tx/Raw is inherited from superclass adi.AD579x.Base
++**Raw - Channel Raw Value**
++   
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5781.Tx/SampleRate is inherited from superclass adi.AD579x.Base
++**SampleRate - Sample Rate**
++   Baseband sampling rate in Hz, specified as a scalar in samples per second.
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5781.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD5781.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD5781.Tx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD5790_Tx.rst b/docs/source/reference_api/AD5790_Tx.rst
+index c3ae293..81db3e5 100644
+--- a/docs/source/reference_api/AD5790_Tx.rst
++++ b/docs/source/reference_api/AD5790_Tx.rst
+@@ -15,8 +15,8 @@ data to the AD5790.
+ Class Properties
+ ================
+ 
+-**CodeSelect Code Select**
+-   Set to 2s_complement/offset_binaryHelp for adi.AD5790.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
++**CodeSelect - Code Select**
++   Set to 2s_complement/offset_binary
+ 
+ **DDSFrequencies DDS Frequencies**
+    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5790.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
+@@ -36,17 +36,17 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**PowerDown Power Down**
+-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5790.Tx/PowerDown is inherited from superclass adi.AD579x.Base
++**PowerDown - Power Down**
++   Set to true/false to power-up/power-down the device channels
+ 
+-**Raw Channel Raw Value**
+-   Help for adi.AD5790.Tx/Raw is inherited from superclass adi.AD579x.Base
++**Raw - Channel Raw Value**
++   
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5790.Tx/SampleRate is inherited from superclass adi.AD579x.Base
++**SampleRate - Sample Rate**
++   Baseband sampling rate in Hz, specified as a scalar in samples per second.
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5790.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD5790.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD5790.Tx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD5791_Tx.rst b/docs/source/reference_api/AD5791_Tx.rst
+index 3f86a53..a4a4827 100644
+--- a/docs/source/reference_api/AD5791_Tx.rst
++++ b/docs/source/reference_api/AD5791_Tx.rst
+@@ -15,8 +15,8 @@ data to the AD5791.
+ Class Properties
+ ================
+ 
+-**CodeSelect Code Select**
+-   Set to 2s_complement/offset_binaryHelp for adi.AD5791.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
++**CodeSelect - Code Select**
++   Set to 2s_complement/offset_binary
+ 
+ **DDSFrequencies DDS Frequencies**
+    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5791.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
+@@ -36,17 +36,17 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**PowerDown Power Down**
+-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5791.Tx/PowerDown is inherited from superclass adi.AD579x.Base
++**PowerDown - Power Down**
++   Set to true/false to power-up/power-down the device channels
+ 
+-**Raw Channel Raw Value**
+-   Help for adi.AD5791.Tx/Raw is inherited from superclass adi.AD579x.Base
++**Raw - Channel Raw Value**
++   
+ 
+-**SampleRate Sample Rate**
+-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5791.Tx/SampleRate is inherited from superclass adi.AD579x.Base
++**SampleRate - Sample Rate**
++   Baseband sampling rate in Hz, specified as a scalar in samples per second.
+ 
+-**SamplesPerFrame Samples Per Frame**
+-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5791.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
++**Frame size**
++   Size of the frame in samplesHelp for adi.AD5791.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD5791.Tx/uri is inherited from superclass matlabshared.libiio.base
+diff --git a/docs/source/reference_api/AD7380_Rx.rst b/docs/source/reference_api/AD7380_Rx.rst
+index 0f39e69..99ee155 100644
+--- a/docs/source/reference_api/AD7380_Rx.rst
++++ b/docs/source/reference_api/AD7380_Rx.rst
+@@ -3,7 +3,7 @@ adi.AD7380.Rx
+ 
+ **AD7380 Precision ADC Class**
+ 
+-adi.AD7380.Rx Receives data from the AD7380 ADC.
++adi.AD7380.Rx Receives data from the AD7380 ADC
+ The adi.AD7380.Rx System object is a signal source that can receive
+ data from the AD7380.
+ 
+@@ -18,12 +18,15 @@ Class Properties
+ **EnabledChannels Enabled Channels**
+    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
+ 
+-**SampleRate Sample Rate**
++**SampleRate - Sample Rate**
+    Baseband sampling rate in Hz, specified as a scalar in samples per second. Options are: '256000','128000','64000','32000','16000','8000','4000', '2000','1000'
+ 
+ **Frame size**
+    Size of the frame in samplesHelp for adi.AD7380.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+ 
++**Data type for the output data**
++   A String Representing the data typeHelp for adi.AD7380.Rx/dataTypeStr is inherited from superclass matlabshared.libiio.base
++
+ **URI - remote host URI**
+    Hostname or IP address of remote libIIO deviceHelp for adi.AD7380.Rx/uri is inherited from superclass matlabshared.libiio.base
+ 
+-- 
+2.34.1
+

--- a/+adi/+AD4020/Rx.m
+++ b/+adi/+AD4020/Rx.m
@@ -10,6 +10,18 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4020 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4020-4021-4022.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0-voltage1'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
@@ -17,6 +29,14 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4021/Rx.m
+++ b/+adi/+AD4021/Rx.m
@@ -10,6 +10,18 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4021 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4020-4021-4022.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0-voltage1'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
@@ -17,6 +29,14 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/+adi/+AD4022/Rx.m
+++ b/+adi/+AD4022/Rx.m
@@ -10,6 +10,18 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
     %
     % `AD4022 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ad4020-4021-4022.pdf>`_
 
+    % Channel names
+    properties (Nontunable, Hidden, Constant)
+        channel_names = {'voltage0-voltage1'}
+    end
+
+    properties (Nontunable)
+        % SampleRate Sample Rate
+        %   Baseband sampling rate in Hz, specified as a scalar
+        %   in samples per second.
+        SampleRate = '1000000'
+    end
+
     methods
         %% Constructor
         function obj = Rx(varargin)
@@ -17,6 +29,14 @@ classdef Rx < adi.AD400x.Base & matlabshared.libiio.base & adi.common.Attribute
             obj.enableExplicitPolling = false;
             obj.EnabledChannels = 1;
             obj.BufferTypeConversionEnable = true;
+        end
+
+        % Set SampleRate
+        function set.SampleRate(obj, value)
+            obj.SampleRate = value;
+            if obj.ConnectedToDevice
+                obj.setAttributeRAW('voltage0-voltage1', 'sampling_frequency', num2str(value), false);
+            end
         end
     end
 end

--- a/docs/source/reference_api/AD4000_Rx.rst
+++ b/docs/source/reference_api/AD4000_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4000.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4000.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4000.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4000.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4000.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4000.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4001_Rx.rst
+++ b/docs/source/reference_api/AD4001_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4001.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4001.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4001.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4001.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4001.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4001.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4002_Rx.rst
+++ b/docs/source/reference_api/AD4002_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4002.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4002.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4002.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4002.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4002.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4002.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4003_Rx.rst
+++ b/docs/source/reference_api/AD4003_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4003.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4003.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4003.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4003.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4003.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4003.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4004_Rx.rst
+++ b/docs/source/reference_api/AD4004_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4004.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4004.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4004.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4004.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4004.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4004.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4005_Rx.rst
+++ b/docs/source/reference_api/AD4005_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4005.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4005.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4005.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4005.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4005.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4005.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4006_Rx.rst
+++ b/docs/source/reference_api/AD4006_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4006.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4006.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4006.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4006.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4006.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4006.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4007_Rx.rst
+++ b/docs/source/reference_api/AD4007_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4007.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4007.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4007.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4007.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4007.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4007.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4008_Rx.rst
+++ b/docs/source/reference_api/AD4008_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4008.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4008.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4008.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4008.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4008.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4008.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4010_Rx.rst
+++ b/docs/source/reference_api/AD4010_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4010.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4010.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4010.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4010.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4010.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4010.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4011_Rx.rst
+++ b/docs/source/reference_api/AD4011_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4011.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4011.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4011.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4011.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4011.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4011.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4020_Rx.rst
+++ b/docs/source/reference_api/AD4020_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4020.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4020.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4020.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4020.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4020.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4020.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4021_Rx.rst
+++ b/docs/source/reference_api/AD4021_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4021.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4021.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4021.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4021.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4021.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4021.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4022_Rx.rst
+++ b/docs/source/reference_api/AD4022_Rx.rst
@@ -19,16 +19,16 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4022.Rx/SampleRate is inherited from superclass adi.AD400x.Base
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4022.Rx/SamplesPerFrame is inherited from superclass adi.AD400x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4022.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
-**VoltageOffset Voltage Offset**
-   ADC Voltage offset.Help for adi.AD4022.Rx/VoltageOffset is inherited from superclass adi.AD400x.Base
+**VoltageOffset - Voltage Offset**
+   ADC Voltage offset.
 
-**VoltageScale Voltage Scale**
-   ADC Voltage scale.Help for adi.AD4022.Rx/VoltageScale is inherited from superclass adi.AD400x.Base
+**VoltageScale - Voltage Scale**
+   ADC Voltage scale.
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4022.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4030_Rx.rst
+++ b/docs/source/reference_api/AD4030_Rx.rst
@@ -19,13 +19,13 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleAveragingLength**
-   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential modeHelp for adi.AD4030.Rx/SampleAveragingLength is inherited from superclass adi.AD463x.Base
+   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential mode
 
-**SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4030.Rx/SampleRate is inherited from superclass adi.AD463x.Base
+**SampleRate - Sample Rate**
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4030.Rx/SamplesPerFrame is inherited from superclass adi.AD463x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4030.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4030.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4052_Rx.rst
+++ b/docs/source/reference_api/AD4052_Rx.rst
@@ -15,20 +15,20 @@ data from the AD4052.
 Class Properties
 ================
 
-**BurstAveragingLength Burst Averaging Length**
-   Length of the averaging filter in 'burst averaging mode'Help for adi.AD4052.Rx/AvgFilterLength is inherited from superclass adi.AD405x.Base
+**AvgFilterLength - BurstAveragingLength Burst Averaging Length**
+   Length of the averaging filter in 'burst averaging mode'
 
-**BurstSampleRate Burst Sample Rate**
-   Rate of internal averaging in 'burst averaging mode'Help for adi.AD4052.Rx/BurstSampleRate is inherited from superclass adi.AD405x.Base
+**BurstSampleRate - Burst Sample Rate**
+   Rate of internal averaging in 'burst averaging mode'
 
 **EnabledChannels Enabled Channels**
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
-**SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4052.Rx/SampleRate is inherited from superclass adi.AD405x.Base
+**SampleRate - Sample Rate**
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4052.Rx/SamplesPerFrame is inherited from superclass adi.AD405x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4052.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4052.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4630_16_Rx.rst
+++ b/docs/source/reference_api/AD4630_16_Rx.rst
@@ -19,13 +19,13 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleAveragingLength**
-   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential modeHelp for adi.AD4630_16.Rx/SampleAveragingLength is inherited from superclass adi.AD463x.Base
+   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential mode
 
-**SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4630_16.Rx/SampleRate is inherited from superclass adi.AD463x.Base
+**SampleRate - Sample Rate**
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4630_16.Rx/SamplesPerFrame is inherited from superclass adi.AD463x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4630_16.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4630_16.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD4630_24_Rx.rst
+++ b/docs/source/reference_api/AD4630_24_Rx.rst
@@ -19,13 +19,13 @@ Class Properties
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
 **SampleAveragingLength**
-   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential modeHelp for adi.AD4630_24.Rx/SampleAveragingLength is inherited from superclass adi.AD463x.Base
+   Block length of samples to be averaged. Applied in the Averaging Mode register only when OUT_DATA_MD is set to 30-bit averaged differential mode
 
-**SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second.Help for adi.AD4630_24.Rx/SampleRate is inherited from superclass adi.AD463x.Base
+**SampleRate - Sample Rate**
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer.Help for adi.AD4630_24.Rx/SamplesPerFrame is inherited from superclass adi.AD463x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD4630_24.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD4630_24.Rx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD5760_Tx.rst
+++ b/docs/source/reference_api/AD5760_Tx.rst
@@ -15,8 +15,8 @@ data to the AD5760.
 Class Properties
 ================
 
-**CodeSelect Code Select**
-   Set to 2s_complement/offset_binaryHelp for adi.AD5760.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
+**CodeSelect - Code Select**
+   Set to 2s_complement/offset_binary
 
 **DDSFrequencies DDS Frequencies**
    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5760.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
@@ -36,17 +36,17 @@ Class Properties
 **EnabledChannels Enabled Channels**
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
-**PowerDown Power Down**
-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5760.Tx/PowerDown is inherited from superclass adi.AD579x.Base
+**PowerDown - Power Down**
+   Set to true/false to power-up/power-down the device channels
 
-**Raw Channel Raw Value**
-   Help for adi.AD5760.Tx/Raw is inherited from superclass adi.AD579x.Base
+**Raw - Channel Raw Value**
+   
 
-**SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5760.Tx/SampleRate is inherited from superclass adi.AD579x.Base
+**SampleRate - Sample Rate**
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5760.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD5760.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD5760.Tx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD5780_Tx.rst
+++ b/docs/source/reference_api/AD5780_Tx.rst
@@ -15,8 +15,8 @@ data to the AD5780.
 Class Properties
 ================
 
-**CodeSelect Code Select**
-   Set to 2s_complement/offset_binaryHelp for adi.AD5780.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
+**CodeSelect - Code Select**
+   Set to 2s_complement/offset_binary
 
 **DDSFrequencies DDS Frequencies**
    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5780.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
@@ -36,17 +36,17 @@ Class Properties
 **EnabledChannels Enabled Channels**
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
-**PowerDown Power Down**
-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5780.Tx/PowerDown is inherited from superclass adi.AD579x.Base
+**PowerDown - Power Down**
+   Set to true/false to power-up/power-down the device channels
 
-**Raw Channel Raw Value**
-   Help for adi.AD5780.Tx/Raw is inherited from superclass adi.AD579x.Base
+**Raw - Channel Raw Value**
+   
 
-**SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5780.Tx/SampleRate is inherited from superclass adi.AD579x.Base
+**SampleRate - Sample Rate**
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5780.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD5780.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD5780.Tx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD5781_Tx.rst
+++ b/docs/source/reference_api/AD5781_Tx.rst
@@ -15,8 +15,8 @@ data to the AD5781.
 Class Properties
 ================
 
-**CodeSelect Code Select**
-   Set to 2s_complement/offset_binaryHelp for adi.AD5781.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
+**CodeSelect - Code Select**
+   Set to 2s_complement/offset_binary
 
 **DDSFrequencies DDS Frequencies**
    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5781.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
@@ -36,17 +36,17 @@ Class Properties
 **EnabledChannels Enabled Channels**
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
-**PowerDown Power Down**
-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5781.Tx/PowerDown is inherited from superclass adi.AD579x.Base
+**PowerDown - Power Down**
+   Set to true/false to power-up/power-down the device channels
 
-**Raw Channel Raw Value**
-   Help for adi.AD5781.Tx/Raw is inherited from superclass adi.AD579x.Base
+**Raw - Channel Raw Value**
+   
 
-**SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5781.Tx/SampleRate is inherited from superclass adi.AD579x.Base
+**SampleRate - Sample Rate**
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5781.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD5781.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD5781.Tx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD5790_Tx.rst
+++ b/docs/source/reference_api/AD5790_Tx.rst
@@ -15,8 +15,8 @@ data to the AD5790.
 Class Properties
 ================
 
-**CodeSelect Code Select**
-   Set to 2s_complement/offset_binaryHelp for adi.AD5790.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
+**CodeSelect - Code Select**
+   Set to 2s_complement/offset_binary
 
 **DDSFrequencies DDS Frequencies**
    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5790.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
@@ -36,17 +36,17 @@ Class Properties
 **EnabledChannels Enabled Channels**
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
-**PowerDown Power Down**
-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5790.Tx/PowerDown is inherited from superclass adi.AD579x.Base
+**PowerDown - Power Down**
+   Set to true/false to power-up/power-down the device channels
 
-**Raw Channel Raw Value**
-   Help for adi.AD5790.Tx/Raw is inherited from superclass adi.AD579x.Base
+**Raw - Channel Raw Value**
+   
 
-**SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5790.Tx/SampleRate is inherited from superclass adi.AD579x.Base
+**SampleRate - Sample Rate**
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5790.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD5790.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD5790.Tx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD5791_Tx.rst
+++ b/docs/source/reference_api/AD5791_Tx.rst
@@ -15,8 +15,8 @@ data to the AD5791.
 Class Properties
 ================
 
-**CodeSelect Code Select**
-   Set to 2s_complement/offset_binaryHelp for adi.AD5791.Tx/CodeSelect is inherited from superclass adi.AD579x.Base
+**CodeSelect - Code Select**
+   Set to 2s_complement/offset_binary
 
 **DDSFrequencies DDS Frequencies**
    Frequencies values in Hz of the DDS tone generators. For complex data devices the input is a [2xN] matrix where N is the available channels on the board. For complex data devices this is at most max(EnabledChannels)*2. For non-complex data devices this is at most max(EnabledChannels). If N < this upper limit, other DDSs are not set.Help for adi.AD5791.Tx/DDSFrequencies is inherited from superclass adi.common.DDS
@@ -36,17 +36,17 @@ Class Properties
 **EnabledChannels Enabled Channels**
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
-**PowerDown Power Down**
-   Set to true/false to power-up/power-down the device channelsHelp for adi.AD5791.Tx/PowerDown is inherited from superclass adi.AD579x.Base
+**PowerDown - Power Down**
+   Set to true/false to power-up/power-down the device channels
 
-**Raw Channel Raw Value**
-   Help for adi.AD5791.Tx/Raw is inherited from superclass adi.AD579x.Base
+**Raw - Channel Raw Value**
+   
 
-**SampleRate Sample Rate**
-   Baseband sampling rate in Hz, specified as a scalar in samples per second. Help for adi.AD5791.Tx/SampleRate is inherited from superclass adi.AD579x.Base
+**SampleRate - Sample Rate**
+   Baseband sampling rate in Hz, specified as a scalar in samples per second.
 
-**SamplesPerFrame Samples Per Frame**
-   Number of samples per frame, specified as an even positive integer. Help for adi.AD5791.Tx/SamplesPerFrame is inherited from superclass adi.AD579x.Base
+**Frame size**
+   Size of the frame in samplesHelp for adi.AD5791.Tx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD5791.Tx/uri is inherited from superclass matlabshared.libiio.base

--- a/docs/source/reference_api/AD7380_Rx.rst
+++ b/docs/source/reference_api/AD7380_Rx.rst
@@ -3,7 +3,7 @@ adi.AD7380.Rx
 
 **AD7380 Precision ADC Class**
 
-adi.AD7380.Rx Receives data from the AD7380 ADC.
+adi.AD7380.Rx Receives data from the AD7380 ADC
 The adi.AD7380.Rx System object is a signal source that can receive
 data from the AD7380.
 
@@ -18,11 +18,14 @@ Class Properties
 **EnabledChannels Enabled Channels**
    Indexs of channels to be enabled. Input should be a [1xN] vector with the indexes of channels to be enabled. Order is irrelevant
 
-**SampleRate Sample Rate**
+**SampleRate - Sample Rate**
    Baseband sampling rate in Hz, specified as a scalar in samples per second. Options are: '256000','128000','64000','32000','16000','8000','4000', '2000','1000'
 
 **Frame size**
    Size of the frame in samplesHelp for adi.AD7380.Rx/SamplesPerFrame is inherited from superclass matlabshared.libiio.base
+
+**Data type for the output data**
+   A String Representing the data typeHelp for adi.AD7380.Rx/dataTypeStr is inherited from superclass matlabshared.libiio.base
 
 **URI - remote host URI**
    Hostname or IP address of remote libIIO deviceHelp for adi.AD7380.Rx/uri is inherited from superclass matlabshared.libiio.base


### PR DESCRIPTION
## AD400x: fix sign for even-numbered devices
The channel name property in Base.m has to be removed, since it varies
between differential and pseudo-differential devices.

Also change where the SampleRate property and the setters are defined - now there's a version in each device class.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [X] I have build all projects affected by the changes in this PR
- [X] I have tested in hardware affected projects, at the relevant boards
- [X] I have signed off all commits from this PR
- [X] I have updated the documentation by running /docs/source/reference_api/gen_sysobj_doc.m script locally, if applies.