### PR TITLE
Add workaround for HDL limitation on DMA for AD4630-24 design

### DIFF
--- a/examples/ad4630_DataCapture.m
+++ b/examples/ad4630_DataCapture.m
@@ -15,7 +15,7 @@ rx.FrameCount = 1;
 
 % Only a select few channel groupings yield sensible outputs. Refer to the
 % Limitations section in the documentation for more details
-rx.EnabledChannels = [1];
+rx.EnabledChannels = [1,2];
 
 % Capture data
 data = rx();


### PR DESCRIPTION
This is a workaround for https://github.com/analogdevicesinc/hdl/issues/2014